### PR TITLE
fix: .default-content-wrapper global padding

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -350,6 +350,10 @@ main .section {
     padding: 64px 16px;
 }
 
+main .section .default-content-wrapper {
+    padding: 14px 14px 48px;
+}
+
 @media (min-width: 600px) {
     main .section {
         padding: 64px 32px;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #64 

Test URLs:
- Before: https://main--bevespi--hlxsites.hlx.page/contact-us
- After: https://feat-page-contact-us--bevespi--hlxsites.hlx.page/
- Page: https://feat-page-contact-us--bevespi--hlxsites.hlx.page/contact-us
