### PR TITLE
Experimental: tile fragments

### DIFF
--- a/blocks/tiles/tiles.css
+++ b/blocks/tiles/tiles.css
@@ -53,7 +53,7 @@
   grid-row: auto / span 2;
 }
 
-.tiles.block > div > .cover h3 {
+.tiles.block > div > .cover h2 {
   margin: 0;
   color: var(--color-blue-2);
   font-weight: 500;
@@ -136,7 +136,7 @@
   font-family: var(--proximanova-font-family);
 }
 
-.tiles.block > .tile.white-text .cover h3 {
+.tiles.block > .tile.white-text .cover h2 {
   color: white;
 }
 
@@ -199,7 +199,7 @@
     width: calc(200% + var(--grid-gap));
   }
 
-  .tiles.block > div > .cover h3 {
+  .tiles.block > div > .cover h2 {
     font-size: 2.9rem;
     font-weight: 600;
     line-height: 1em;
@@ -246,12 +246,12 @@
 }
 
 /* Numbered elements */
-.tiles.block > div.tile.numbered .cover  h3 {
+.tiles.block > div.tile.numbered .cover  h2 {
   color: white;
   font-weight: 400;
 }
 
-.tiles.block > div.tile.numbered .cover  h3:first-of-type {
+.tiles.block > div.tile.numbered .cover  h2:first-of-type {
   font-size: 7rem;
   font-weight: 200;
   font-style: italic;
@@ -259,17 +259,17 @@
   font-family: var(--proximanova-font-family);
 }
 
-.tiles.block > div.tile.numbered .cover h3:last-of-type {
+.tiles.block > div.tile.numbered .cover h2:last-of-type {
   margin-bottom: auto;
 }
 
-.tiles.block > div.tile.numbered .cover h3 strong {
+.tiles.block > div.tile.numbered .cover h2 strong {
   color: var(--color-green);
   display: inline-block;
 }
 
 @media (min-width: 900px) {
-  .tiles.block > div.tile.numbered .cover  h3:first-of-type {
+  .tiles.block > div.tile.numbered .cover  h2:first-of-type {
     font-size: 9rem;
   }
 }

--- a/blocks/tiles/tiles.js
+++ b/blocks/tiles/tiles.js
@@ -6,11 +6,30 @@ function closeOtherModals(block) {
   });
 }
 
+const classesToMap = {
+  'six-tips-to-help': '/html-fragments/six-tips.html',
+  'five-ways-to-enjoy-time': '/html-fragments/five-ways-to-enjoy.html',
+  'four-common-triggers': '/html-fragments/four-common-triggers.html',
+};
+
+async function loadMappings(tile, cover) {
+  await Promise.all([...tile.classList].map(async (c) => {
+    if (Object.keys(classesToMap).includes(c)) {
+      const fragment = await fetch(classesToMap[c]);
+      if (fragment.ok) {
+        cover.outerHTML = await fragment.text();
+        tile.classList.remove(c);
+        tile.classList.remove('numbered');
+      }
+    }
+  }));
+}
+
 export default function decorate(block) {
   block.querySelectorAll(':scope > div').forEach(async (tile) => {
     tile.classList.add('tile');
 
-    const cover = tile.querySelector(':scope > div:first-child');
+    let cover = tile.querySelector(':scope > div:first-child');
     const modalContent = tile.querySelector(':scope > div:nth-child(2)');
     const propertiesElement = tile.querySelector(':scope > div:nth-child(3)');
 
@@ -29,11 +48,8 @@ export default function decorate(block) {
       h3.parentElement.insertBefore(document.createElement('hr'), h3.nextSibling);
     }
 
-    // if (tile.classList.contains('six-tips-to-help')) {
-    //   const fragment = await fetch('/html-fragments/six-tips.html');
-    //   cover.innerHTML = await fragment.text();
-    //   // tile.classList.remove('six-tips-to-help');
-    // }
+    await loadMappings(tile, cover);
+    cover = tile.querySelector('.cover') ?? cover;
 
     if (modalContent.classList.contains('button-container')) {
       // only has a button. Then the tile becomes a link

--- a/blocks/tiles/tiles.js
+++ b/blocks/tiles/tiles.js
@@ -44,8 +44,8 @@ export default function decorate(block) {
     picture?.closest('p').replaceWith(picture);
 
     if (tile.classList.contains('with-separator')) {
-      const h3 = tile.querySelector('h3:last-of-type');
-      h3.parentElement.insertBefore(document.createElement('hr'), h3.nextSibling);
+      const h2 = tile.querySelector('h2:last-of-type');
+      h2.parentElement.insertBefore(document.createElement('hr'), h2.nextSibling);
     }
 
     await loadMappings(tile, cover);

--- a/html-fragments/five-ways-to-enjoy.html
+++ b/html-fragments/five-ways-to-enjoy.html
@@ -1,7 +1,7 @@
 <style>
     .five-ways-to-enjoy h3 .title-flex > span:first-child {
       color: var(--color-green);
-      font-size: 14.103rem;
+      font-size: 7rem;
       line-height: 1;
       font-family: var(--proximanova-font-family);
       font-weight: 200;
@@ -14,15 +14,15 @@
 
     .five-ways-to-enjoy h3 .title-flex > div > span:first-child {
       padding-top: 15px;
-      font-size: 2.275rem;
       display: block;
       color: var(--color-green);
+      font-size: 1.3rem;
     }
 
     .five-ways-to-enjoy h3 .title-flex > div > span:nth-child(2) {
       display: block;
       color: var(--color-green);
-      font-size: 3.4rem;
+      font-size: 1.8rem;
       line-height: 1;
     }
 
@@ -33,6 +33,21 @@
     .five-ways-to-enjoy h3 > span {
       font-weight: 500;
     }
+
+    @media (min-width: 600px) {
+      .five-ways-to-enjoy h3 .title-flex > span:first-child {
+        font-size: 14.103rem;
+      }
+
+      .five-ways-to-enjoy h3 .title-flex > div > span:nth-child(2) {
+        font-size: 3.4rem;
+      }
+
+      .five-ways-to-enjoy h3 .title-flex > div > span:first-child {
+        font-size: 2.275rem;
+      }
+    }
+
 </style>
 
 <div class="cover with-modal five-ways-to-enjoy">

--- a/html-fragments/five-ways-to-enjoy.html
+++ b/html-fragments/five-ways-to-enjoy.html
@@ -1,5 +1,5 @@
 <style>
-    .five-ways-to-enjoy h3 .title-flex > span:first-child {
+    .five-ways-to-enjoy h2 .title-flex > span:first-child {
       color: var(--color-green);
       font-size: 7rem;
       line-height: 1;
@@ -8,42 +8,42 @@
       font-style: italic;
     }
 
-    .five-ways-to-enjoy h3 .title-flex > div {
+    .five-ways-to-enjoy h2 .title-flex > div {
       padding-left: 10px;
     }
 
-    .five-ways-to-enjoy h3 .title-flex > div > span:first-child {
+    .five-ways-to-enjoy h2 .title-flex > div > span:first-child {
       padding-top: 15px;
       display: block;
       color: var(--color-green);
       font-size: 1.3rem;
     }
 
-    .five-ways-to-enjoy h3 .title-flex > div > span:nth-child(2) {
+    .five-ways-to-enjoy h2 .title-flex > div > span:nth-child(2) {
       display: block;
       color: var(--color-green);
       font-size: 1.8rem;
       line-height: 1;
     }
 
-    .five-ways-to-enjoy h3 .title-flex {
+    .five-ways-to-enjoy h2 .title-flex {
       display: flex;
     }
 
-    .five-ways-to-enjoy h3 > span {
+    .five-ways-to-enjoy h2 > span {
       font-weight: 500;
     }
 
     @media (min-width: 600px) {
-      .five-ways-to-enjoy h3 .title-flex > span:first-child {
+      .five-ways-to-enjoy h2 .title-flex > span:first-child {
         font-size: 14.103rem;
       }
 
-      .five-ways-to-enjoy h3 .title-flex > div > span:nth-child(2) {
+      .five-ways-to-enjoy h2 .title-flex > div > span:nth-child(2) {
         font-size: 3.4rem;
       }
 
-      .five-ways-to-enjoy h3 .title-flex > div > span:first-child {
+      .five-ways-to-enjoy h2 .title-flex > div > span:first-child {
         font-size: 2.275rem;
       }
     }
@@ -57,7 +57,7 @@
         <source type="image/png" srcset="./media_1defa2f62c9945d91997996775e8f36e76b56fe69.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
         <img loading="lazy" alt="https://www.bevespi.com/content/dam/website-services/us/417-bevespi-consumer-rwd/images/consumer_breathing/bg-things-to-do-desktop.png" src="./media_1defa2f62c9945d91997996775e8f36e76b56fe69.png?width=750&amp;format=png&amp;optimize=medium" width="310" height="623">
     </picture>
-    <h3>
+    <h2>
         <div class="title-flex">
             <span>5</span>
             <div>
@@ -66,5 +66,5 @@
             </div>
         </div>
         <span>with your kids or grandkids</span>
-    </h3>
+    </h2>
 </div>

--- a/html-fragments/five-ways-to-enjoy.html
+++ b/html-fragments/five-ways-to-enjoy.html
@@ -1,0 +1,55 @@
+<style>
+    .five-ways-to-enjoy h3 .title-flex > span:first-child {
+      color: var(--color-green);
+      font-size: 14.103rem;
+      line-height: 1;
+      font-family: var(--proximanova-font-family);
+      font-weight: 200;
+      font-style: italic;
+    }
+
+    .five-ways-to-enjoy h3 .title-flex > div {
+      padding-left: 10px;
+    }
+
+    .five-ways-to-enjoy h3 .title-flex > div > span:first-child {
+      padding-top: 15px;
+      font-size: 2.275rem;
+      display: block;
+      color: var(--color-green);
+    }
+
+    .five-ways-to-enjoy h3 .title-flex > div > span:nth-child(2) {
+      display: block;
+      color: var(--color-green);
+      font-size: 3.4rem;
+      line-height: 1;
+    }
+
+    .five-ways-to-enjoy h3 .title-flex {
+      display: flex;
+    }
+
+    .five-ways-to-enjoy h3 > span {
+      font-weight: 500;
+    }
+</style>
+
+<div class="cover with-modal five-ways-to-enjoy">
+    <picture>
+        <source type="image/webp" srcset="./media_1defa2f62c9945d91997996775e8f36e76b56fe69.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+        <source type="image/webp" srcset="./media_1defa2f62c9945d91997996775e8f36e76b56fe69.png?width=750&amp;format=webply&amp;optimize=medium">
+        <source type="image/png" srcset="./media_1defa2f62c9945d91997996775e8f36e76b56fe69.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+        <img loading="lazy" alt="https://www.bevespi.com/content/dam/website-services/us/417-bevespi-consumer-rwd/images/consumer_breathing/bg-things-to-do-desktop.png" src="./media_1defa2f62c9945d91997996775e8f36e76b56fe69.png?width=750&amp;format=png&amp;optimize=medium" width="310" height="623">
+    </picture>
+    <h3>
+        <div class="title-flex">
+            <span>5</span>
+            <div>
+                <span>WAYS</span>
+                <span>TO ENJOY TIME</span>
+            </div>
+        </div>
+        <span>with your kids or grandkids</span>
+    </h3>
+</div>

--- a/html-fragments/four-common-triggers.html
+++ b/html-fragments/four-common-triggers.html
@@ -1,4 +1,28 @@
-<div class="cover with-modal open-right">
+<style>
+    .four-common-triggers h3 {
+        margin-bottom: auto;
+    }
+
+    .four-common-triggers h3 span:nth-child(1) {
+      display: block;
+      font-size: 10.2rem;
+      line-height: 1em;
+      font-family: var(--proximanova-font-family);
+      font-weight: 200;
+      font-style: italic;
+      color: var(--color-green);
+    }
+
+    .four-common-triggers h3 span:nth-child(2) {
+      font-weight: 600;
+      color: var(--color-green);
+    }
+
+    .four-common-triggers h3 span:nth-child(3) {
+      font-weight: 500;
+    }
+</style>
+<div class="cover four-common-triggers">
     <picture>
         <source type="image/webp" srcset="./media_1b2912c3acd39f8fe2bfd19bd9287583d1cb9f23b.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
         <source type="image/webp" srcset="./media_1b2912c3acd39f8fe2bfd19bd9287583d1cb9f23b.png?width=750&amp;format=webply&amp;optimize=medium">

--- a/html-fragments/four-common-triggers.html
+++ b/html-fragments/four-common-triggers.html
@@ -1,9 +1,9 @@
 <style>
-    .four-common-triggers h3 {
+    .four-common-triggers h2 {
         margin-bottom: auto;
     }
 
-    .four-common-triggers h3 span:nth-child(1) {
+    .four-common-triggers h2 span:nth-child(1) {
       display: block;
       font-size: 7rem;
       line-height: 1em;
@@ -13,17 +13,17 @@
       color: var(--color-green);
     }
 
-    .four-common-triggers h3 span:nth-child(2) {
+    .four-common-triggers h2 span:nth-child(2) {
       font-weight: 600;
       color: var(--color-green);
     }
 
-    .four-common-triggers h3 span:nth-child(3) {
+    .four-common-triggers h2 span:nth-child(3) {
       font-weight: 500;
     }
 
     @media (min-width: 600px) {
-      .four-common-triggers h3 span:nth-child(1) {
+      .four-common-triggers h2 span:nth-child(1) {
         font-size: 10.2rem;
       }
     }
@@ -35,13 +35,13 @@
         <source type="image/png" srcset="./media_1b2912c3acd39f8fe2bfd19bd9287583d1cb9f23b.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
         <img loading="lazy" alt="https://www.bevespi.com/content/dam/website-services/us/417-bevespi-consumer-rwd/images/consumer_breathing/bg-common-triggers-desktop.png" src="./media_1b2912c3acd39f8fe2bfd19bd9287583d1cb9f23b.png?width=750&amp;format=png&amp;optimize=medium" width="310" height="623">
     </picture>
-    <h3>
+    <h2>
         <span>4</span>
         <span style="
             font-weight: 600;
         ">COMMON TRIGGERS THAT CAN MAKE IT</span>
         <span>TOUGH TO BREATHE</span>
-    </h3>
+    </h2>
     <hr>
     <p>See what they are</p>
 </div>

--- a/html-fragments/four-common-triggers.html
+++ b/html-fragments/four-common-triggers.html
@@ -5,7 +5,7 @@
 
     .four-common-triggers h3 span:nth-child(1) {
       display: block;
-      font-size: 10.2rem;
+      font-size: 7rem;
       line-height: 1em;
       font-family: var(--proximanova-font-family);
       font-weight: 200;
@@ -20,6 +20,12 @@
 
     .four-common-triggers h3 span:nth-child(3) {
       font-weight: 500;
+    }
+
+    @media (min-width: 600px) {
+      .four-common-triggers h3 span:nth-child(1) {
+        font-size: 10.2rem;
+      }
     }
 </style>
 <div class="cover four-common-triggers">

--- a/html-fragments/six-tips.html
+++ b/html-fragments/six-tips.html
@@ -1,5 +1,5 @@
 <style>
-    .six-tips h3 span:first-child {
+    .six-tips h2 span:first-child {
       font-size: 4.5rem;
       line-height: 1;
       font-family: var(--proximanova-font-family);
@@ -8,16 +8,16 @@
       color: var(--color-green);
     }
 
-    .six-tips h3 span:nth-child(2) {
+    .six-tips h2 span:nth-child(2) {
       color: var(--color-green);
     }
 
-    .six-tips h3 span:nth-child(3) {
+    .six-tips h2 span:nth-child(3) {
       display: block;
     }
 
     @media (min-width: 600px) {
-      .six-tips h3 span:first-child {
+      .six-tips h2 span:first-child {
         font-size: 10.2rem;
       }
     }
@@ -30,12 +30,12 @@
         <source type="image/png" srcset="./media_15b3b31bf77f0aea57823c912f17d7228d0bc8f7f.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
         <img loading="lazy" alt="https://www.bevespi.com/content/dam/website-services/us/417-bevespi-consumer-rwd/images/consumer_breathing/bg-tips-desktop.png" src="./media_15b3b31bf77f0aea57823c912f17d7228d0bc8f7f.png?width=750&amp;format=png&amp;optimize=medium" width="310" height="310">
     </picture>
-    <h3>
+    <h2>
         <span>6</span>
         <span>TIPS</span>
         <span>TO HELP YOU</span>
         <span>GET ACTIVE</span>
-    </h3>
+    </h2>
     <hr>
     <p>Staying active <em>can help you breathe better</em></p>
 </div>

--- a/html-fragments/six-tips.html
+++ b/html-fragments/six-tips.html
@@ -1,6 +1,6 @@
 <style>
     .six-tips h3 span:first-child {
-      font-size: 10.2rem;
+      font-size: 4.5rem;
       line-height: 1;
       font-family: var(--proximanova-font-family);
       font-weight: 300;
@@ -14,6 +14,12 @@
 
     .six-tips h3 span:nth-child(3) {
       display: block;
+    }
+
+    @media (min-width: 600px) {
+      .six-tips h3 span:first-child {
+        font-size: 10.2rem;
+      }
     }
 </style>
 

--- a/html-fragments/six-tips.html
+++ b/html-fragments/six-tips.html
@@ -1,4 +1,23 @@
-<div class="cover with-modal">
+<style>
+    .six-tips h3 span:first-child {
+      font-size: 10.2rem;
+      line-height: 1;
+      font-family: var(--proximanova-font-family);
+      font-weight: 300;
+      font-style: italic;
+      color: var(--color-green);
+    }
+
+    .six-tips h3 span:nth-child(2) {
+      color: var(--color-green);
+    }
+
+    .six-tips h3 span:nth-child(3) {
+      display: block;
+    }
+</style>
+
+<div class="cover with-modal six-tips">
     <picture>
         <source type="image/webp" srcset="./media_15b3b31bf77f0aea57823c912f17d7228d0bc8f7f.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
         <source type="image/webp" srcset="./media_15b3b31bf77f0aea57823c912f17d7228d0bc8f7f.png?width=750&amp;format=webply&amp;optimize=medium">
@@ -8,7 +27,8 @@
     <h3>
         <span>6</span>
         <span>TIPS</span>
-        <span>TO HELP YOU GET ACTIVE</span>
+        <span>TO HELP YOU</span>
+        <span>GET ACTIVE</span>
     </h3>
     <hr>
     <p>Staying active <em>can help you breathe better</em></p>


### PR DESCRIPTION
This PR is a suggestion for how we can solve the styling for the custom styled tiles on the tiles block. Open to feedback - we don't have to use it, especially if the customer is fine with having a simpler design.

The custom tiles are stored as html fragments in the code. The rationale for this is: If the content were stored in sharepoint, any content change would need to involve a developer and code change anyway, as here really every word is potentially styled differently. So we may as well simplify and move the content to the code too.

If we want to use this approach, I'd suggest not loading based on class name as it is now (this is just for backward compatibility with the other PR), but to just place a link to the fragment in the block.

Test URLs:
- Before: https://copd-mgmt-resources-page--bevespi--hlxsites.hlx.page/drafts/hhertach/copd-management-resources
- After: https://experimental-fragments--bevespi--hlxsites.hlx.page/drafts/hhertach/copd-management-resources
