### PR TITLE
Apply font gotham-light when necessary

### DIFF
--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -16,7 +16,7 @@
 }
 
 @font-face {
-    font-family: gotham;
+    font-family: gotham-light;
     font-style: normal;
     font-weight: 300;
     font-display: swap;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -47,6 +47,7 @@
     --body-font-family: gotham, gotham-fallback-body;
     --heading-font-family: gotham, gotham-fallback-heading;
     --proximanova-font-family: proxima-nova, serif;
+    --gotham-light-font-family: gotham-light;
     --fixed-font-family: var(--body-font-family);
 
     /* body sizes */
@@ -506,6 +507,12 @@ main .section.green-accent .default-content-wrapper em {
     font-weight: 500;
 }
 
+main .section.green-accent .default-content-wrapper em u {
+    font-family: var(--gotham-light-font-family);
+    color: var(--color-white);
+    text-decoration: none;
+}
+
 main .section.isi {
     font-size: 1.5rem;
     line-height: 1;
@@ -731,8 +738,7 @@ main .section.small-vertical-margins {
     }
 
     .copd-causes-container .default-content-wrapper p,
-    .copd-causes-container .default-content-wrapper h2,
-    {
+    .copd-causes-container .default-content-wrapper h2 {
         text-align: center;
     }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #123 

Tried version of setting the text as italic and undelined in order to apply the `gotham-light` font

Test URLs:
- Before: https://main--bevespi--hlxsites.hlx.page/drafts/msalan/copd-management-resources
- After: https://issue-123-apply-gotham-light--bevespi--hlxsites.hlx.page/drafts/msalan/copd-management-resources
