### PR TITLE
remove span close (as in original)

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -271,15 +271,6 @@ header .nav-middle > div > div > div div:nth-of-type(3) .close {
   display: none;
 }
 
-header .expanded .nav-middle > div > div > div div:nth-of-type(3) .close {
-  display: block;
-  color: var(--background-color);
-}
-
-header .expanded .nav-middle > div > div > div div:nth-of-type(3) .explore {
-  display: none;
-}
-
 @media (min-width: 900px) {
   header .nav-top {
     height: 40px;

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -44,7 +44,7 @@ export default async function decorate(block) {
 
     const explore = nav.querySelector('.nav-middle > div > div > div > div:nth-of-type(3)');
     if (explore) {
-      explore.innerHTML = "<span class='explore'>Explore</span><span class='close'>Close</span>";
+      explore.innerHTML = "<span class='explore'>Explore</span>";
       explore.addEventListener('click', () => { nav.classList.toggle('expanded'); });
     }
 


### PR DESCRIPTION
Fix #155 

Test URLs:
- Before: https://main--bevespi--hlxsites.hlx.page/
- After: https://155-close-button-misplaced--bevespi--hlxsites.hlx.page/

Note: I could not reproduce the issue, hence I am trying to fix it by removing the 'Close' button entirely and just keeping the 'Explore', which is exactly the same behavior as in original site
