### PR TITLE
fix external link decorator: protect from a tag without href

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -66,7 +66,7 @@ export function getEnvType(hostname = window.location.hostname) {
 */
 export function decorateExternalLinks(container) {
   container.querySelectorAll('a').forEach((a) => {
-    if (!a.getAttribute('href').startsWith('/')) a.setAttribute('target', '_blank');
+    if (!a.getAttribute('href')?.startsWith('/')) a.setAttribute('target', '_blank');
   });
 }
 


### PR DESCRIPTION
Fix #216

Test URLs:
- Before: https://main--bevespi--hlxsites.hlx.page/
- After: https://216-external-links-break-the-page--bevespi--hlxsites.hlx.page/
