### PR TITLE
getting started page: sections background fix

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1204,6 +1204,7 @@ main .section.centered p:has(picture:first-child:last-child) {
 
 .getting-started main .section.grey {
     background-color: var(--background-grey-4);
+    background-image: none;
 }
 
 .getting-started main div:not(.isi) .default-content-wrapper .button-container {
@@ -1629,6 +1630,12 @@ h2 > br::after {
         padding-top: 55px;
         padding-bottom: 0;
     }
+}
+
+.getting-started main .section:nth-of-type(6) {
+    background-image: url('../images/bg-section-2.png');
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
 }
 
 .getting-started main .section.hero-container + .section {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -842,6 +842,12 @@ main .section.hero-container + .section {
     padding-top: 32px;
 }
 
+.getting-started main .section:nth-of-type(6) {
+    background-image: url('../images/bg-section-2.png');
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+}
+
 .copd-resources main .section.hero-container + .section {
     padding-top: 32px;
 }
@@ -1315,6 +1321,7 @@ h2 > br {
         margin-bottom: 22px;
     }
 
+    /* stylelint-disable-next-line */
     #understanding-copdemphysema--chronic-bronchitis {
         margin-bottom: 37px;
     }
@@ -1630,12 +1637,6 @@ h2 > br::after {
         padding-top: 55px;
         padding-bottom: 0;
     }
-}
-
-.getting-started main .section:nth-of-type(6) {
-    background-image: url('../images/bg-section-2.png');
-    background-repeat: no-repeat;
-    background-size: 100% 100%;
 }
 
 .getting-started main .section.hero-container + .section {


### PR DESCRIPTION
Test URLs:
- Before: https://main--bevespi--hlxsites.hlx.page/copd-management-resources/getting-started-on-bevespi
- After: https://az-03-11-4--bevespi--hlxsites.hlx.page/copd-management-resources/getting-started-on-bevespi

http://localhost:3000/copd-management-resources/getting-started-on-bevespi
https://www.bevespi.com/copd-management-resources/getting-started-on-bevespi.html


<img width="397" alt="Screenshot 2023-11-03 at 10 45 45" src="https://github.com/hlxsites/bevespi/assets/111385/d7ea25f3-dd5b-4011-98e5-aef5c2bfb341">
