### PR TITLE
remove margin 0 of the getting started hero h1

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -931,10 +931,6 @@ main .section.small-vertical-margins {
         margin: 40px 0 30px;
     }
 
-    .getting-started main .hero:not(.home) > div:nth-of-type(n+2) > div h1 {
-        margin-top: 0;
-    }
-
     .sitemap main .hero:not(.home) > div:nth-of-type(n+2) > div h1 {
         margin-top: 0;
     }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #411 

Test URLs:
- Before: https://main--bevespi--hlxsites.hlx.page/copd-management-resources/getting-started-on-bevespi
- After: https://issue-411--bevespi--hlxsites.hlx.page/copd-management-resources/getting-started-on-bevespi
