### PR TITLE
Image not consistent on bevespi-side-effects

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -159,6 +159,22 @@ main .hero > div:first-of-type picture {
   box-sizing: border-box;
 }
 
+.side-effects main .hero > div:first-of-type picture {
+  left: -75%;
+}
+
+@media (min-width: 350px) {
+  .side-effects main .hero > div:first-of-type picture {
+    left: -10%;
+  }
+}
+
+@media (min-width: 600px) {
+  .side-effects main .hero > div:first-of-type picture {
+    left: 0;
+  }
+}
+
 main .hero > div:first-of-type p > picture {
   display: none;
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -159,6 +159,10 @@ main .hero > div:first-of-type picture {
   box-sizing: border-box;
 }
 
+main .hero > div:first-of-type p > picture {
+  display: none;
+}
+
 .side-effects main .hero > div:first-of-type picture {
   left: -75%;
 }
@@ -173,10 +177,6 @@ main .hero > div:first-of-type picture {
   .side-effects main .hero > div:first-of-type picture {
     left: 0;
   }
-}
-
-main .hero > div:first-of-type p > picture {
-  display: none;
 }
 
 main .hero > div:first-of-type p:last-of-type > picture {


### PR DESCRIPTION
Fix issue with image not being completly displayed on various device width sizes

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #459 

Test URLs:
- Before: https://main--bevespi--hlxsites.hlx.page/bevespi-side-effects
- After: https://issue-459--bevespi--hlxsites.hlx.page/bevespi-side-effects
