### PR TITLE
Fix issue with arrow not being displayed on very large displays on about-copd pages

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -67,6 +67,12 @@ main .hero img {
   }
 }
 
+@media (min-width: 1600px) {
+  .about-copd main .hero img {
+    object-fit: fill;
+  }
+}
+
 main .hero.home .btn-scroll {
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #451 

Test URLs:
- Before: https://main--bevespi--hlxsites.hlx.page/about-copd/what-is-chronic-obstructive-pulmonary-disease
- After: https://issue-451--bevespi--hlxsites.hlx.page/about-copd/what-is-chronic-obstructive-pulmonary-disease

Fix is for all pages under /about-copd/
