### PR TITLE
Add min-height to opened tile modal on desktop

### DIFF
--- a/blocks/tiles/tiles.css
+++ b/blocks/tiles/tiles.css
@@ -238,6 +238,7 @@
 
   .tiles.block .cover[aria-expanded] + .modal {
     width: calc(200% + var(--grid-gap));
+    min-height: min(100%, var(--tile-height));
   }
 
   .tiles.block .modal h2 {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #476 

Test URLs:
- Before: https://main--bevespi--hlxsites.hlx.page/copd-management-resources
- After: https://fix-tile-modal-display--bevespi--hlxsites.hlx.page/copd-management-resources
